### PR TITLE
Refacto: Move CTC decoder from Keras Backend to tf.nn

### DIFF
--- a/doctr/models/detection/differentiable_binarization.py
+++ b/doctr/models/detection/differentiable_binarization.py
@@ -120,6 +120,9 @@ class DBPostProcessor(DetectionPostProcessor):
         # get contours from connected components on the bitmap
         contours, _ = cv2.findContours(bitmap.astype(np.uint8), cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
         for contour in contours[:self.max_candidates]:
+            # Check whether smallest enclosing bounding box is not too small
+            if np.any(contour[:, 0].max(axis=0) - contour[:, 0].min(axis=0) <= 5):
+                continue
             epsilon = 0.01 * cv2.arcLength(contour, True)
             approx = cv2.approxPolyDP(contour, epsilon, True)  # approximate contour by a polygon
             points = approx.reshape((-1, 2))  # get polygon points

--- a/doctr/models/recognition/crnn.py
+++ b/doctr/models/recognition/crnn.py
@@ -59,7 +59,6 @@ class CRNN(RecognitionModel):
         # B x W x H x C --> B x W x H * C
         features_seq = tf.reshape(transposed_feat, shape=(-1, w, h * c))
         decoded_features = self.decoder(features_seq, **kwargs)
-
         return decoded_features
 
 


### PR DESCRIPTION
This PR replaces keras ctc decoder which seems deprecated by tf.nn ctc decoder